### PR TITLE
【Fixed】ステップ11: タスク一覧を作成日時の順番で並び替え

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: "DESC")
   end
 
   def show

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,23 +2,27 @@
 <%= render 'layouts/messages' %>
 
 <table>
-  <tr>
-    <th><%= t('view.name') %></th>　
-    <th><%= t('view.detail') %></th>
-    <th><%= t('view.created_at') %></th>
-    <th>詳細</th>
-    <th>編集</th>
-    <th>削除</th>
-  </tr>
-  <% @tasks.each do |task| %>
+  <thead>
     <tr>
-      <td><%= task.name %></td>
-      <td><%= task.detail %></td>
-      <td><%= task.created_at.strftime('%Y年%m月%d日 %H時%M分%S秒') %></td>
-      <td><%= link_to "詳細", task_path(task.id) %></td>
-      <td><%= link_to "編集", edit_task_path(task.id) %></td>
-      <td><%= link_to '削除', task_path(task.id), method: :delete ,data: { confirm: '本当に削除していいですか？' } %></td>
+      <th><%= t('view.name') %></th>　
+      <th><%= t('view.detail') %></th>
+      <th><%= t('view.created_at') %></th>
+      <th>詳細</th>
+      <th>編集</th>
+      <th>削除</th>
     </tr>
+   </thead>
+  <% @tasks.each do |task| %>
+    <tbody>
+      <tr>
+        <td><%= task.name %></td>
+        <td><%= task.detail %></td>
+        <td><%= task.created_at.strftime('%Y年%m月%d日 %H時%M分%S秒') %></td>
+        <td><%= link_to "詳細", task_path(task.id) %></td>
+        <td><%= link_to "編集", edit_task_path(task.id) %></td>
+        <td><%= link_to '削除', task_path(task.id), method: :delete ,data: { confirm: '本当に削除していいですか？' } %></td>
+      </tr>
+    </tbody>
   <% end %>
 </table>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,6 +5,7 @@
   <tr>
     <th><%= t('view.name') %></th>　
     <th><%= t('view.detail') %></th>
+    <th><%= t('view.created_at') %></th>
     <th>詳細</th>
     <th>編集</th>
     <th>削除</th>
@@ -13,6 +14,7 @@
     <tr>
       <td><%= task.name %></td>
       <td><%= task.detail %></td>
+      <td><%= task.created_at.strftime('%Y年%m月%d日 %H時%M分%S秒') %></td>
       <td><%= link_to "詳細", task_path(task.id) %></td>
       <td><%= link_to "編集", edit_task_path(task.id) %></td>
       <td><%= link_to '削除', task_path(task.id), method: :delete ,data: { confirm: '本当に削除していいですか？' } %></td>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   view:
     name: タスク名
     detail: タスク詳細
+    created_at: タスク作成日時
   activerecord:
     attributes:
       task:

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :task do
+    name { 'test_task_01'}
+    detail { 'testtesttest' }
+  end
+
+  factory :second_task, class: Task do
+    name { 'test_task_03'}
+    detail { 'samplesample' }
+  end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.feature "タスク管理機能", type: :feature do
   background do
-    FactoryBot.create(:task, id: 1, name:"test_task_01")
-    FactoryBot.create(:task, id: 2, name:"test_task_02")
-    FactoryBot.create(:second_task, id: 3, name:"test_task_03")
+    FactoryBot.create(:task, name:"test_task_01")
+    FactoryBot.create(:task, name:"test_task_02")
+    FactoryBot.create(:second_task, name:"test_task_03")
   end
 
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do
     visit tasks_path
-    expect(Task.order(created_at: "DESC").map(&:id)).to eq [3,2,1]
+    expect(first('tr')).to have_content 'samplesample'
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,25 +1,14 @@
 require 'rails_helper'
 
 RSpec.feature "タスク管理機能", type: :feature do
-  scenario "タスク一覧のテスト" do
-    Task.create!(name: 'test_task_01', detail: 'testtesttest')
-    Task.create!(name: 'test_task_02', detail: 'samplesample')
+  background do
+    FactoryBot.create(:task, name:"test_task_01")
+    FactoryBot.create(:task, name:"test_task_02")
+    FactoryBot.create(:second_task, name:"test_task_03")
+  end
+
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
     visit tasks_path
-    expect(page).to have_content('testtesttest')
-    expect(page).to have_content('samplesample')
-  end
-
-  scenario "タスク作成のテスト" do
-    visit new_task_path
-    fill_in 'task_name', with:'test_task_01'
-    fill_in 'task_detail', with: 'testtesttest'
-    click_button '登録する'
-    expect(page).to have_content('testtesttest')
-  end
-
-  scenario "タスク詳細のテスト" do
-    Task.create!(name: 'test_task_01', detail: 'testtesttest')
-    visit '/tasks/4'
-    expect(page).to have_content('testtesttest')
+    expect(Task.all.order(created_at: "DESC")).to eq [name: "test_task_03", name: "test_task_02",name: "test_task_01"]
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -9,6 +9,6 @@ RSpec.feature "タスク管理機能", type: :feature do
 
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do
     visit tasks_path
-    expect(first('tr')).to have_content 'samplesample'
+    expect(first("table")).to have_content 'samplesample'
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "タスク管理機能", type: :feature do
   background do
     FactoryBot.create(:task, id: 1, name:"test_task_01")
     FactoryBot.create(:task, id: 2, name:"test_task_02")
-    FactoryBot.create(:task, id: 3, name:"test_task_03")
+    FactoryBot.create(:second_task, id: 3, name:"test_task_03")
   end
 
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.feature "タスク管理機能", type: :feature do
   background do
-    FactoryBot.create(:task, name:"test_task_01")
-    FactoryBot.create(:task, name:"test_task_02")
-    FactoryBot.create(:second_task, name:"test_task_03")
+    FactoryBot.create(:task, id: 1, name:"test_task_01")
+    FactoryBot.create(:task, id: 2, name:"test_task_02")
+    FactoryBot.create(:task, id: 3, name:"test_task_03")
   end
 
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do
     visit tasks_path
-    expect(Task.all.order(created_at: "DESC")).to eq [name: "test_task_03", name: "test_task_02",name: "test_task_01"]
+    expect(Task.order(created_at: "DESC").map(&:id)).to eq [3,2,1]
   end
 end


### PR DESCRIPTION
Issues/#7
・タスク一覧を作成日時の降順で並び替え（開発環境・テスト環境）